### PR TITLE
update setup.py to exclude 'tests' package and sub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     keywords="hyperion ambilight",
     url="https://github.com/dermotduffy/hyperion-py",
     package_data={"hyperion-py": ["py.typed"]},
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests","tests.*"]),
     platforms="any",
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
```
 * Package:    dev-python/hyperion-py-0.6.0
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   dermot.duffy@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking hyperion-py-0.6.0.tar.gz to /var/tmp/portage/dev-python/hyperion-py-0.6.0/work
>>> Source unpacked in /var/tmp/portage/dev-python/hyperion-py-0.6.0/work
>>> Preparing source in /var/tmp/portage/dev-python/hyperion-py-0.6.0/work/hyperion-py-0.6.0 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/hyperion-py-0.6.0/work/hyperion-py-0.6.0 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/hyperion-py-0.6.0/work/hyperion-py-0.6.0 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
python3.8 setup.py build -j 10
running build
running build_py
...
running install_egg_info
running egg_info
writing hyperion_py.egg-info/PKG-INFO
writing dependency_links to hyperion_py.egg-info/dependency_links.txt
writing top-level names to hyperion_py.egg-info/top_level.txt
reading manifest file 'hyperion_py.egg-info/SOURCES.txt'
writing manifest file 'hyperion_py.egg-info/SOURCES.txt'
Copying hyperion_py.egg-info to /var/tmp/portage/dev-python/hyperion-py-0.6.0/image/_python3.8/usr/lib/python3.8/site-packages/hyperion_py-0.6.0-py3.8.egg-info
running install_scripts
 * ERROR: dev-python/hyperion-py-0.6.0::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  125:  Called src_install
 *   environment, line 2969:  Called distutils-r1_src_install
 *   environment, line 1196:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  443:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2585:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2067:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2065:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  800:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1164:  Called distutils-r1_python_install
 *   environment, line 1083:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
```