### PR TITLE
fix brightness state for multi profile configs

### DIFF
--- a/hyperion/client.py
+++ b/hyperion/client.py
@@ -878,9 +878,8 @@ class HyperionClient:
         """Update adjustment."""
         if (
             self._serverinfo is None
-            or adjustment is None
+            or not adjustment
             or type(adjustment) != list
-            or type(adjustment[0]) != dict
         ):
             return
         self._serverinfo[const.KEY_ADJUSTMENT] = adjustment

--- a/hyperion/client.py
+++ b/hyperion/client.py
@@ -880,7 +880,6 @@ class HyperionClient:
             self._serverinfo is None
             or adjustment is None
             or type(adjustment) != list
-            or len(adjustment) != 1
             or type(adjustment[0]) != dict
         ):
             return


### PR DESCRIPTION
This nasty little bug took me quite some time to figure out.
The brightness was not updating correctly and I was assuming it was caused by the callbacks not comming through, but it turned out the internal state of this upstream lib was just not updated if the adjustment contained more than 1 entry (multi profile config)

Could you please merge and push to a new version as soon as possible?
Then I can finish PR: https://github.com/home-assistant/core/pull/45335